### PR TITLE
「数で遊ぼう」の修正

### DIFF
--- a/docs/play-with-number/codelab.json
+++ b/docs/play-with-number/codelab.json
@@ -3,7 +3,7 @@
   "format": "html",
   "prefix": "https://storage.googleapis.com",
   "mainga": "UA-49880327-14",
-  "updated": "2021-04-23T11:37:14Z",
+  "updated": "2021-04-23T12:00:41Z",
   "id": "play-with-number",
   "duration": 60,
   "title": "数で遊ぼう 〜 コマンドラインツールで数を操る",

--- a/docs/play-with-number/codelab.json
+++ b/docs/play-with-number/codelab.json
@@ -3,7 +3,7 @@
   "format": "html",
   "prefix": "https://storage.googleapis.com",
   "mainga": "UA-49880327-14",
-  "updated": "2021-04-23T07:19:02Z",
+  "updated": "2021-04-23T11:37:14Z",
   "id": "play-with-number",
   "duration": 60,
   "title": "数で遊ぼう 〜 コマンドラインツールで数を操る",

--- a/docs/play-with-number/index.html
+++ b/docs/play-with-number/index.html
@@ -50,7 +50,7 @@
         <p>GitHub からコードラボで利用するサンプルコードを取得しましょう。</p>
 <pre>$ git clone https://github.com/WomenWhoGoTokyo/codelab.git</pre>
 <p>Google Cloud Shell をご利用の方は、<a href="https://github.com/WomenWhoGoTokyo/codelab/tree/master/play-with-number" target="_blank">https://github.com/WomenWhoGoTokyo/codelab/tree/master/play-with-number</a> の「OPEN IN GOOGLE CLOUD SHELL」ボタンを押下してコードを取得してください。<img style="width: 601.70px" src="img/265fac3df769e316.png"></p>
-<p><code>コードが取</code>得できたら codelab/play-with-number というディレクトリが作られていることを確認しましょう。</p>
+<p>コードが取得できたら <code>codelab/play-with-number</code> というディレクトリが作られていることを確認しましょう。</p>
 <pre>$ cd codelab/play-with-number
 $ ls
 README.md go.mod  main.go   prime</pre>
@@ -123,7 +123,7 @@ func TestPrime(t *testing.T) {
                 }
         }
 }</code></pre>
-<p>これは、<code>prime/prime.go に書かれている Prime という関数をテストするための処理です。入力した数値が素数である 5 の場合は true を、素数ではない 6 の場合は false を返す処理が書かれています。</code></p>
+<p>これは、<code>prime/prime.go</code>に書かれている Prime という関数をテストするための処理です。入力した数値が素数である 5 の場合は true を、素数ではない 6 の場合は false を返す処理が書かれています。</p>
 <p><code>テストを実行してみましょう。</code></p>
 <pre>$ cd prime
 $ go test</pre>
@@ -139,8 +139,8 @@ FAIL        github.com/WomenWhoGoTokyo/codelab/play-with-number/prime        0.4
       </google-codelab-step>
     
       <google-codelab-step label="main関数を確認する" duration="15">
-        <p><code>まず、main関数を確認しましょう。</code></p>
-<p><code>PrimeNumDeterminer </code>関数で、<code>Prime</code>関数の戻り値が <code>true だった場合に「素数です」と出力し、戻り値が true でなかった場合「素数ではありません」と出力する処理をしています。</code></p>
+        <p>まず、main関数を確認しましょう。</p>
+<p>PrimeNumDeterminer関数で、Prime関数の戻り値が true だった場合に「素数です」と出力し、戻り値が true でなかった場合「素数ではありません」と出力する処理をしています。</p>
 <p><code>codelab/play-with-number/main.go</code></p>
 <pre><code>...（略）
 
@@ -155,7 +155,7 @@ func PrimeNumDeterminer(num int) {
 }
 
 ...（略）</code></pre>
-<p><code>また</code>、コンソールに入力した値を読み取る処理で、<code>flagパッケージを使っています。</code></p>
+<p>また、コンソールに入力した値を読み取る処理で、<code>flag</code>パッケージを使っています。</p>
 <p><code>codelab/play-with-number/main.go</code></p>
 <pre><code>package main
 
@@ -212,8 +212,8 @@ func main() {
       </google-codelab-step>
     
       <google-codelab-step label="Prime関数を修正する" duration="10">
-        <p><code>まず</code>、 prime.go の <code>IsPrime </code>関数を確認します。<code>prime とは日本語で素数のことです。</code></p>
-<p><code>IsPrime関数では、コ</code>マンドラインで引数として与えられた文字列を n とし、nが素数であるか否かの判定を行います。nが素数かどうかは、「１より大きい整数で、平方根をとってそれ以下の素数で割り切れる場合」に素数であると判定できます。</p>
+        <p>まず、 prime.go の <code>IsPrime </code>関数を確認します。prime とは日本語で素数のことです。</p>
+<p><code>IsPrime</code>関数では、コマンドラインで引数として与えられた文字列を n とし、nが素数であるか否かの判定を行います。nが素数かどうかは、「１より大きい整数で、平方根をとってそれ以下の素数で割り切れる場合」に素数であると判定できます。</p>
 <p><code>codelab/play-with-number/prime/prime.go</code></p>
 <pre><code>package prime
 
@@ -233,9 +233,9 @@ func IsPrime(n int) bool {
         }
         return result
 }</code></pre>
-<p><code>IsPrime関数で行っている処理を上から見ていきましょう。</code></p>
-<p><code>まず、コマンドラインで文字列（string型）として与えられたnをfloat64型に型変換しています。さらに、mathパッケージのSqrt関数を使い、その平方根を取得してsquarerootという変数に代入しています。square rootとは日本語で平方根のことです。</code></p>
-<p><code>続くループ処理で、nが２から自分自身までの自然数で割り切れた場合は結果をtrueとし、割り切れずにあまりが出た場合は結果をfalseとすることで、素数かどうかの判定ができるようになります。</code></p>
+<p><code>IsPrime</code>関数で行っている処理を上から見ていきましょう。</p>
+<p>まず、コマンドラインで文字列（string型）として与えられたnをfloat64型に型変換しています。さらに、mathパッケージのSqrt関数を使い、その平方根を取得してsquarerootという変数に代入しています。square rootとは日本語で平方根のことです。</p>
+<p>続くループ処理で、nが２から自分自身までの自然数で割り切れた場合は結果をtrueとし、割り切れずにあまりが出た場合は結果をfalseとすることで、素数かどうかの判定ができるようになります。</p>
 <p>この処理を書くと、プログラムは次のようになります。</p>
 <p><code>codelab/play-with-number/prime/prime.go</code></p>
 <pre><code>package prime
@@ -256,7 +256,7 @@ func IsPrime(n int) bool {
         }
         return result
 }</code></pre>
-<p><code>更新したプログラムを保存したら、再度バイナリをビルドして、もう一度primeモードで素数判定を実行してみましょう。</code></p>
+<p>更新したプログラムを保存したら、再度バイナリをビルドして、もう一度primeモードで素数判定を実行してみましょう。</p>
 <pre>$ go build -v -o play-with-number</pre>
 <pre>$ ./play-with-number -game prime
 数字を入力してください
@@ -277,7 +277,7 @@ $ go test</pre>
 <pre>PASS
 ok          github.com/WomenWhoGoTokyo/codelab/play-with-number/prime        0.228s</pre>
 <p>期待通りにテストがパスしました。</p>
-<p>本当に素数が判定できているかどうか確認するために、テストケースを増やしてテストを実行してみます。<code>1</code> から <code>13 までの整数をテストケースに追加します。</code></p>
+<p>本当に素数が判定できているかどうか確認するために、テストケースを増やしてテストを実行してみます。1 から 13 までの整数をテストケースに追加します。</p>
 <p><code>codelab/play-with-number/prime/prime_test.go</code></p>
 <pre><code>package prime
 

--- a/docs/play-with-number/index.html
+++ b/docs/play-with-number/index.html
@@ -233,9 +233,9 @@ func IsPrime(n int) bool {
         }
         return result
 }</code></pre>
-<p><code>IsPrime</code>関数で行っている処理を上から見ていきましょう。</p>
-<p>まず、コマンドラインで文字列（string型）として与えられたnをfloat64型に型変換しています。さらに、mathパッケージのSqrt関数を使い、その平方根を取得してsquarerootという変数に代入しています。square rootとは日本語で平方根のことです。</p>
-<p>続くループ処理で、nが２から自分自身までの自然数で割り切れた場合は結果をtrueとし、割り切れずにあまりが出た場合は結果をfalseとすることで、素数かどうかの判定ができるようになります。</p>
+<p><code>IsPrime </code>関数で行っている処理を上から見ていきましょう。</p>
+<p>まず、コマンドラインで文字列（string型）として与えられた<code>n</code>を <code>float64</code> 型に型変換しています。さらに、mathパッケージの <code>Sqrt</code> 関数を使い、その平方根を取得して<code>squareroot </code>という変数に代入しています。square root とは日本語で平方根のことです。</p>
+<p>続くループ処理で、<code>n </code>が 2 から自分自身までの自然数で割り切れた場合は結果を <code>true </code>とし、割り切れずに余りが出た場合は結果を <code>false</code>とすることで、素数かどうかの判定ができるようになります。</p>
 <p>この処理を書くと、プログラムは次のようになります。</p>
 <p><code>codelab/play-with-number/prime/prime.go</code></p>
 <pre><code>package prime
@@ -363,57 +363,53 @@ FAIL        github.com/WomenWhoGoTokyo/codelab/play-with-number/prime        0.3
 
       </google-codelab-step>
     
-      <google-codelab-step label="main関数を修正する" duration="5">
-        <p><code>main.goのma</code>in 関数コードを保存したら、もう一度テストを実行してみましょう。</p>
-<p><code>codelab/play-with-number/main.go</code></p>
-<pre><code>package main
+      <google-codelab-step label="IsPrime関数を修正する" duration="5">
+        <p>もう一度、<code>prime.go </code>の<code>IsPrime </code> 関数を確認します。</p>
+<p><code>codelab/play-with-number/prime/prime.go</code></p>
+<pre><code>package prime
 
 import (
-        &#34;flag&#34;
-        &#34;fmt&#34;
-        &#34;strconv&#34;
-        &#34;time&#34;
-
-        &#34;github.com/WomenWhoGoTokyo/codelab/play-with-number/prime&#34;
+        &#34;math&#34;
 )
 
-var game string
+func IsPrime(n int) bool {
+        squareroot := math.Sqrt(float64(n))
+        result := true
 
-const (
-        defaultGame = &#34;&#34;
-        usage       = &#34;ゲームのメニューを選択&#34;
-)
-
-func init() {
-        flag.StringVar(&amp;game, &#34;game&#34;, defaultGame, usage)
-}
-
-func main() {
-        var (
-                num int
-                err error
-        )
-
-        flag.Parse()
-
-        switch game {
-        case &#34;prime&#34;:
-                fmt.Print(&#34;数字を入力してください\n&#34;)
-                fmt.Scan(&amp;num)
-        case &#34;todayis&#34;:
-                num, err = convertTodayToNum()
-                if err != nil {
-                        fmt.Println(err)
-                        return
+        for i := 2; i &lt;= int(squareroot); i++ {
+                if n%i == 0 {
+                        result = false
+                        break
                 }
-        default:
-                fmt.Print(&#34;オプションを指定してください&#34;)
-                return
         }
-        PrimeNumDeterminer(num)
-}
+        return result
+}</code></pre>
+<p>ループ処理の中の条件分岐で、入力された値が1だった場合に <code>result</code> に <code>false</code> を代入する処理を追加しましょう。</p>
+<p><code>switch 文を使い、入力された値が1の場合と、それ以外の場合で分岐します。if文を使うこともできますが、簡潔に書くことができるため、Goではこのような場合に switch 文を使うことが多いです。</code></p>
+<p><code>codelab/play-with-number/prime/prime.go</code></p>
+<pre><code>package prime
 
-...（略）</code></pre>
+import (
+        &#34;math&#34;
+)
+
+func IsPrime(n int) bool {
+        squareroot := math.Sqrt(float64(n))
+        result := true
+
+        for i := 2; i &lt;= int(squareroot); i++ {
+                switch n {
+                case 1:
+                        result = false
+                default:
+                        if n%i == 0 {
+                                result = false
+                                break
+                        }
+                }
+        }
+        return result
+}</code></pre>
 <p>修正したコードを保存したら、もう一度テストを実行してみましょう。</p>
 <pre>$ pwd
 /Users/{ユーザー名}/dev/codelab/play-with-number/prime
@@ -428,7 +424,7 @@ ok          github.com/WomenWhoGoTokyo/codelab/play-with-number/prime        0.3
     
       <google-codelab-step label="さいごに" duration="5">
         <p>このコードラボでは、素数を判定するゲームを題材に、Goでコマンドラインツールをつくりそのテストを実行する体験をしました。</p>
-<p>Goでは、標準パッケージを使って簡単にコマンドラインツールをつくることができるので、みなさんも趣味や業務に役立つツールを作ってみてください。</p>
+<p>Goでは、標準パッケージを使って簡単にコマンドラインツールをつくることができるので、みなさんも趣味や業務に役立つツールをつくってみてください。</p>
 
 
       </google-codelab-step>

--- a/docs/play-with-number/index.html
+++ b/docs/play-with-number/index.html
@@ -102,7 +102,7 @@ README.md go.mod  main.go   prime</pre>
 
 import &#34;testing&#34;
 
-func TestPrime(t *testing.T) {
+func TestIsPrime(t *testing.T) {
 
         tests := []struct {
                 arg  int
@@ -118,8 +118,8 @@ func TestPrime(t *testing.T) {
                 },
         }
         for _, tt := range tests {
-                if got := Prime(tt.arg); got != tt.want {
-                        t.Errorf(&#34;Prime() = %v, want %v&#34;, got, tt.want)
+                if got := IsPrime(tt.arg); got != tt.want {
+                        t.Errorf(&#34;IIsPrime(%v) = %v, want %v&#34;, got, tt.want)
                 }
         }
 }</code></pre>
@@ -129,7 +129,7 @@ func TestPrime(t *testing.T) {
 $ go test</pre>
 <p>テストの実行結果が出力されました。</p>
 <pre>--- FAIL: TestPrime (0.00s)
-    prime_test.go:22: Prime() = true, want false
+    prime_test.go:22: IsPrime() = true, want false
 FAIL
 exit status 1
 FAIL        github.com/WomenWhoGoTokyo/codelab/play-with-number/prime        0.452s</pre>
@@ -145,7 +145,7 @@ FAIL        github.com/WomenWhoGoTokyo/codelab/play-with-number/prime        0.4
 <pre><code>...（略）
 
 func PrimeNumDeterminer(num int) {
-        result := prime.Prime(num)
+        result := prime.IsPrime(num)
         switch result {
         case // TODO: 素数の場合の条件分岐処理を書く
                 fmt.Printf(&#34;%dは%s\n&#34;, num, &#34;素数です&#34;)
@@ -343,7 +343,7 @@ func TestPrime(t *testing.T) {
                 },
         }
         for _, tt := range tests {
-                if got := Prime(tt.arg); got != tt.want {
+                if got := IsPrime(tt.arg); got != tt.want {
                         t.Errorf(&#34;Prime() = %v, want %v&#34;, got, tt.want)
                 }
         }

--- a/docs/play-with-number/index.html
+++ b/docs/play-with-number/index.html
@@ -73,7 +73,7 @@ README.md go.mod  main.go   prime</pre>
 <p><code>go build</code> を実行すると、バイナリファイルが生成されます。</p>
 <p class="image-container"><img style="width: 601.70px" src="img/510aaacbcbea7b03.png"></p>
 <p>このゲームには二つのモードがあります。</p>
-<p>一つ目は <code>todayis</code> モード、二つ目は <code>prime</code> モードです。</p>
+<p>一つ目は <code>todayis</code> モード、二つ目は <code>prime</code> モードです。<code>todayis</code> モードは、本日の日付を6桁の数字にしたものが素数かどうかを判定します。 <code>primeモードは、入力した任意の数字が素数かどうかを判定します。 </code></p>
 <p>まずtodayisモードから試してみましょう。</p>
 <p>実行オプションで <code>-game</code> を指定し、引数に <code>todayis</code> を入れて、バイナリファイルを実行してみましょう。</p>
 <pre>$ ./play-with-number -game todayis
@@ -83,12 +83,12 @@ README.md go.mod  main.go   prime</pre>
 <p>実行オプションで <code>-game</code> を指定し、引数に <code>prime</code> を入れて、バイナリファイルを実行してみましょう。</p>
 <pre>$ ./play-with-number -game prime</pre>
 <p>実行するとコンソールに 「数字を入力してください」と表示されます。</p>
-<p><code>好きな数字を入力してみましょう。まず試しに、素数である 5 を入力してみます。</code></p>
+<p>好きな文字を入力してみましょう。まず試しに、素数ではない6を入力してみます。</p>
 <pre>$ ./play-with-number -game prime
 数字を入力してください
-5
-5は素数ではありません</pre>
-<p>入力した数字 <code>5</code> は素数ではないという、期待と異なる結果が出力されました。</p>
+6
+は素数です</pre>
+<p>入力した数字 <code>6</code> は素数であるという、期待と異なる結果が出力されました。</p>
 <p>次の項からは、期待した結果が返ってくるようにプログラムを修正していきます。</p>
 
 
@@ -128,8 +128,8 @@ func TestIsPrime(t *testing.T) {
 <pre>$ cd prime
 $ go test</pre>
 <p>テストの実行結果が出力されました。</p>
-<pre>--- FAIL: TestPrime (0.00s)
-    prime_test.go:22: IsPrime() = true, want false
+<pre>--- FAIL: TestIsPrime (0.00s)
+    prime_test.go:22: IsPrime(6) = true, want false
 FAIL
 exit status 1
 FAIL        github.com/WomenWhoGoTokyo/codelab/play-with-number/prime        0.452s</pre>
@@ -139,8 +139,8 @@ FAIL        github.com/WomenWhoGoTokyo/codelab/play-with-number/prime        0.4
       </google-codelab-step>
     
       <google-codelab-step label="main関数を確認する" duration="15">
-        <p>まず、main関数を確認しましょう。</p>
-<p>PrimeNumDeterminer関数で、Prime関数の戻り値が true だった場合に「素数です」と出力し、戻り値が true でなかった場合「素数ではありません」と出力する処理をしています。</p>
+        <p><code>まず、codelab/play-with-number ディレクトリにあるmain.goファイルの main 関数を確認しましょう。</code></p>
+<p><code>PrimeNumDeterminer </code>関数で、<code>Prime</code> 関数の戻り値が <code>true だった場合に「素数です」と出力し、戻り値が true でなかった場合「素数ではありません」と出力する処理をしています。</code></p>
 <p><code>codelab/play-with-number/main.go</code></p>
 <pre><code>...（略）
 
@@ -267,7 +267,7 @@ func IsPrime(n int) bool {
 
       </google-codelab-step>
     
-      <google-codelab-step label="テストケースを増やす" duration="10">
+      <google-codelab-step label="テストケースを増やす" duration="5">
         <p>書き直した Go のプログラムが期待通り動作するか確認するために、もう一度テストを実行してみましょう。</p>
 <pre>$ pwd
 /Users/{ユーザー名}/dev/codelab/play-with-number/prime
@@ -348,6 +348,73 @@ func TestPrime(t *testing.T) {
                 }
         }
 }</code></pre>
+<pre>$ pwd
+/Users/{ユーザー名}/dev/codelab/play-with-number/prime
+
+$ go test</pre>
+<pre>--- FAIL: TestIsPrime (0.00s)
+    prime_test.go:66: IsPrime(1) = true, want false
+FAIL
+exit status 1
+FAIL        github.com/WomenWhoGoTokyo/codelab/play-with-number/prime        0.322s</pre>
+<p>1の場合も <code>prime</code>関数の戻り値が <code>true</code> となっており、テストが落ちています。</p>
+<p>１は素数ではないので、判定処理のプログラムを修正しましょう。</p>
+
+
+      </google-codelab-step>
+    
+      <google-codelab-step label="main関数を修正する" duration="5">
+        <p><code>main.goのma</code>in 関数コードを保存したら、もう一度テストを実行してみましょう。</p>
+<p><code>codelab/play-with-number/main.go</code></p>
+<pre><code>package main
+
+import (
+        &#34;flag&#34;
+        &#34;fmt&#34;
+        &#34;strconv&#34;
+        &#34;time&#34;
+
+        &#34;github.com/WomenWhoGoTokyo/codelab/play-with-number/prime&#34;
+)
+
+var game string
+
+const (
+        defaultGame = &#34;&#34;
+        usage       = &#34;ゲームのメニューを選択&#34;
+)
+
+func init() {
+        flag.StringVar(&amp;game, &#34;game&#34;, defaultGame, usage)
+}
+
+func main() {
+        var (
+                num int
+                err error
+        )
+
+        flag.Parse()
+
+        switch game {
+        case &#34;prime&#34;:
+                fmt.Print(&#34;数字を入力してください\n&#34;)
+                fmt.Scan(&amp;num)
+        case &#34;todayis&#34;:
+                num, err = convertTodayToNum()
+                if err != nil {
+                        fmt.Println(err)
+                        return
+                }
+        default:
+                fmt.Print(&#34;オプションを指定してください&#34;)
+                return
+        }
+        PrimeNumDeterminer(num)
+}
+
+...（略）</code></pre>
+<p>修正したコードを保存したら、もう一度テストを実行してみましょう。</p>
 <pre>$ pwd
 /Users/{ユーザー名}/dev/codelab/play-with-number/prime
 

--- a/play-with-number/prime/prime_test.go
+++ b/play-with-number/prime/prime_test.go
@@ -19,7 +19,7 @@ func TestIsPrime(t *testing.T) {
 	}
 	for _, tt := range tests {
 		if got := IsPrime(tt.arg); got != tt.want {
-			t.Errorf("Prime() = %v, want %v", got, tt.want)
+			t.Errorf("IsPrime(%v) = %v, want %v", tt.arg, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
- [x] 参加者がコードを各部分が少ないのでコードの一部をコメントにする
- [x] 1の場合素数であると判定されてしまうので、素数でないと判定する処理を追加する