### PR TITLE
[image-slender]Goのバージョンアップ&READMEの修正

### DIFF
--- a/docs/tutorial-concurrency-go/index.html
+++ b/docs/tutorial-concurrency-go/index.html
@@ -97,7 +97,7 @@ func BenchmarkExecute(b *testing.B) {
                 execute()
         }
 }</code></pre>
-<p>これは、<code>main.go に書かれている execute という関数のベンチマークを実行するための処理です。実行してみましょう。</code></p>
+<p>これは、<code>main.go</code> に書かれている execute という関数のベンチマークを実行するための処理です。実行してみましょう。</p>
 <pre>$ go test -count 10 -bench BenchmarkExecute</pre>
 <p>ベンチマークの実行結果が出力されました。</p>
 <pre>goos: darwin

--- a/docs/tutorial-concurrency-go/index.html
+++ b/docs/tutorial-concurrency-go/index.html
@@ -160,7 +160,7 @@ import (
 
         &#34;github.com/jinzhu/configor&#34;
         &#34;github.com/mi-bear/image-slender/slender&#34;
-        &#34;golang.org/x/sync/errgroup&#34;
+        &#34;golang.org/x/sync/errgroup&#34; // 追加する
 )
 .
 .
@@ -185,10 +185,17 @@ func execute() error {
         return nil
 }</code></pre>
 <p><code>errgroup</code> は、<code>errgroup.Go</code> の処理をすべて実行し終わるまで、<code>errgroup.Wait</code> が呼ばれることはありません。また、<code>errgroup.Go</code> でエラーが発生したら、そのうち一番最初のエラーを返却します。 </p>
-<pre>$ go build -v -o image-slender
-$ ./image-slender</pre>
+
 <p> 更新したプログラムを保存したら、実行してみましょう。</p>
 
+<p> まず新しくimportした<code>golang.org/x/sync/errgroup</code>  パッケージを <code>go mod </code>コマンドを使ってインストールします。</p>
+<pre>$ go mod tidy
+go: finding module for package golang.org/x/sync/errgroup
+go: found golang.org/x/sync/errgroup in golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+</pre>
+<p>go buildしてバイナリファイルを実行しましょう。</p>
+<pre>$ go build -v -o image-slender
+$ ./image-slender</pre>
 
       </google-codelab-step>
     

--- a/image-slender/README.md
+++ b/image-slender/README.md
@@ -1,5 +1,6 @@
 # image-slender
 https://womenwhogotokyo.github.io/codelab/image-slender/
+
 ## Run the Benchmark
 ```
 $ go test -count 10 -test.bench BenchmarkExecute

--- a/image-slender/README.md
+++ b/image-slender/README.md
@@ -1,8 +1,8 @@
 # image-slender
-
+https://womenwhogotokyo.github.io/codelab/image-slender/
 ## Run the Benchmark
 ```
 $ go test -count 10 -test.bench BenchmarkExecute
 ```
 
-[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FWomenWhoGoTokyo%2Fcodelab)
+[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/WomenWhoGoTokyo/codelab.git&cloudshell_workspace=image-slender)

--- a/image-slender/README.md
+++ b/image-slender/README.md
@@ -1,5 +1,5 @@
 # image-slender
-https://womenwhogotokyo.github.io/codelab/image-slender/
+https://womenwhogotokyo.github.io/codelab/tutorial-concurrency-go/
 
 ## Run the Benchmark
 ```

--- a/image-slender/go.mod
+++ b/image-slender/go.mod
@@ -1,9 +1,14 @@
 module github.com/WomenWhoGoTokyo/codelab/image-slender
 
-go 1.14
+go 1.18
 
 require (
 	github.com/jinzhu/configor v1.1.1
 	github.com/pkg/errors v0.9.1
 	golang.org/x/image v0.0.0-20200119044424-58c23975cae1
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/image-slender/go.mod
+++ b/image-slender/go.mod
@@ -1,6 +1,6 @@
 module github.com/WomenWhoGoTokyo/codelab/image-slender
 
-go 1.18
+go 1.17
 
 require (
 	github.com/jinzhu/configor v1.1.1

--- a/image-slender/go.mod
+++ b/image-slender/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/jinzhu/configor v1.1.1
-	github.com/pkg/errors v0.9.1
 	golang.org/x/image v0.0.0-20200119044424-58c23975cae1
 )
 

--- a/image-slender/go.sum
+++ b/image-slender/go.sum
@@ -7,6 +7,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 golang.org/x/image v0.0.0-20200119044424-58c23975cae1 h1:5h3ngYt7+vXCDZCup/HkCQgW5XwmSvR/nA2JmJ0RErg=
 golang.org/x/image v0.0.0-20200119044424-58c23975cae1/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/image-slender/go.sum
+++ b/image-slender/go.sum
@@ -9,5 +9,6 @@ golang.org/x/image v0.0.0-20200119044424-58c23975cae1/go.mod h1:FeLwcggjj3mMvU+o
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/image-slender/go.sum
+++ b/image-slender/go.sum
@@ -2,8 +2,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/jinzhu/configor v1.1.1 h1:gntDP+ffGhs7aJ0u8JvjCDts2OsxsI7bnz3q+jC+hSY=
 github.com/jinzhu/configor v1.1.1/go.mod h1:nX89/MOmDba7ZX7GCyU/VIaQ2Ar2aizBl2d3JLF/rDc=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/image v0.0.0-20200119044424-58c23975cae1 h1:5h3ngYt7+vXCDZCup/HkCQgW5XwmSvR/nA2JmJ0RErg=
 golang.org/x/image v0.0.0-20200119044424-58c23975cae1/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/image-slender/slender/slender.go
+++ b/image-slender/slender/slender.go
@@ -1,6 +1,7 @@
 package slender
 
 import (
+	"errors"
 	"fmt"
 	"image"
 	"image/gif"
@@ -10,8 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"golang.org/x/image/draw"
 )


### PR DESCRIPTION
# 概要
https://github.com/WomenWhoGoTokyo/codelab/issues/99
issueのうち以下2つに対応します。

# やること
- [x] Go のバージョン UP
- [x] README がないやつは足す
Open in Cloud Shell のリンクの修正はこちらに追従しました: https://github.com/WomenWhoGoTokyo/codelab/pull/104/files

# レビューポイント
Go v1.8ではなくv1.7を使うべきか