### PR TITLE
一覧ページのアップデート

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.vscode

--- a/docs/claat.bash
+++ b/docs/claat.bash
@@ -5,7 +5,7 @@ codelabs=(
     "gocon-2018-autumn-setup"   "1nBB9Sl-mnKE5htc_Fbx_-Q3VUY1YIfF_C3Wi_HFgzoo"
     "gocon-2019-spring-setup"   "1SBE8eGYPdnZVuMffOA0t4OT_6sxndTjNqmEOv-d61mA"
     "gocon-2019-autumn-setup"   "1y9GR6RntgL7R-Ll3R_LGVy-c_lsibk5-txsbu2R5xQI"
-    "google-cloud-shell-go"     "1tmQBU8WtUIQ_Yb2STllFCa3lE8DQsMFnkikvcjMjF1c"
+    "google-cloud-shell-go-solo" "19rSvwntPRo0eZzZa44HBeJ2j0OX15vqh6CewrGatEF4"
     "google-app-engine-go"      "1AjOewYLEtWy-x8RGQtxQe1vMCTKia15CK3iKczmfoQM"
     "google-cloud-functions-go" "1uwGLNnjLfFky0mvQuAKu7CIVTt6jO2rIMD4AkxrRUj4"
     "tutorial-concurrency-go" "1iFi9Dq1Aw-iH-cJ8JqyoaQdrOgVDwk41Or3p1Xf93lM"

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@
 
 クラウド上で Go の開発ができるツールを利用する手順が記載されているコンテンツです。
 
-- [Google Cloud Shell で Go の開発をはじめよう](./google-cloud-shell-go?index=codelab) by [micchie](https://twitter.com/micchiebear)
+- [Google Cloud Shell で Go の開発をはじめよう](./google-cloud-shell-go-solo?index=codelab) by [micchie](https://twitter.com/micchiebear), [Misato](https://twitter.com/mikkegt)
 
 
 ## Amigurumi Gophers

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 - [Google App Engine で Go を動かしてみよう](./google-app-engine-go?index=codelab) by [micchie](https://twitter.com/micchiebear)
 - [Google Cloud Functions で Go を動かしてみよう](./google-cloud-functions-go?index=codelab) by [micchie](https://twitter.com/micchiebear)
 - [Go の並行処理を体験してみよう](./tutorial-concurrency-go/?index=codelab) by [micchie](https://twitter.com/micchiebear)
-- [数で遊ぼう 〜 コマンドラインツールで数を操る](./play-with-number?index=codelab) by [miki](https://twitter.com/mikisslv09), [mom0tomo](https://twitter.com/mom0tomo), [micchie](https://twitter.com/micchiebear)
+- [数で遊ぼう 〜 コマンドラインツールで数を操る](./play-with-number?index=codelab) by [miki](https://twitter.com/mikiislv09), [mom0tomo](https://twitter.com/mom0tomo), [micchie](https://twitter.com/micchiebear)
 
 ## サブコンテンツ
 
@@ -30,6 +30,6 @@
 ## Amigurumi Gophers
 Amigurumi Gophersによる編み物コンテンツです。
 
-- [初めて編むGopher](./gopher-amigurumi/ja?index=codelab) by [miki](https://twitter.com/mikisslv09), [mihohoi](https://twitter.com/Danny_miho)
+- [初めて編むGopher](./gopher-amigurumi/ja?index=codelab) by [miki](https://twitter.com/mikiislv09), [mihohoi](https://twitter.com/Danny_miho)
 
-- [The First Gopher Amigurumi](./gopher-amigurumi/en?index=codelab) by [miki](https://twitter.com/mikisslv09), [mihohoi](https://twitter.com/Danny_miho)
+- [The First Gopher Amigurumi](./gopher-amigurumi/en?index=codelab) by [miki](https://twitter.com/mikiislv09), [mihohoi](https://twitter.com/Danny_miho)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 - [Google App Engine で Go を動かしてみよう](./google-app-engine-go?index=codelab) by [micchie](https://twitter.com/micchiebear)
 - [Google Cloud Functions で Go を動かしてみよう](./google-cloud-functions-go?index=codelab) by [micchie](https://twitter.com/micchiebear)
 - [Go の並行処理を体験してみよう](./tutorial-concurrency-go/?index=codelab) by [micchie](https://twitter.com/micchiebear)
-- [数で遊ぼう 〜 コマンドラインツールで数を操る](./play-with-number?index=codelab) by [miki](https://twitter.com/mikisslv09), [mom0tomo](https://twitter.com/mom0tomo), [mi-bear](https://twitter.com/micchiebear)
+- [数で遊ぼう 〜 コマンドラインツールで数を操る](./play-with-number?index=codelab) by [miki](https://twitter.com/mikisslv09), [mom0tomo](https://twitter.com/mom0tomo), [micchie](https://twitter.com/micchiebear)
 
 ## サブコンテンツ
 


### PR DESCRIPTION
# 概要
Google Cloud Shellのcodelabのリンクを今回Misatoさんが作ってくれたものに更新しました。
併せて細かなアップデートをしました。

変更内容は、commitログを見ていただいた方がわかりやすいかもしれません。

# レビュー観点
- https://womenwhogotokyo.github.io/codelab/ のリンクを入れ替える形にしたが、違和感はないか（コレ↓）
![スクリーンショット 2022-04-02 8 55 43](https://user-images.githubusercontent.com/16359292/161454335-296abefd-9777-4b19-af9f-403c2217a116.png)

タイトルが同じだと見分けがつかない&今後、wwgt-codelabs というプロジェクトを使ってもらうことはないかも？と思ったので、入れ替える形にして見たのですが、両方併記した方がよいでしょうか？



