### PR TITLE
古い記述が残っていたので削除・修正する

### DIFF
--- a/docs/google-cloud-functions-go/index.html
+++ b/docs/google-cloud-functions-go/index.html
@@ -90,25 +90,7 @@ require cloud.google.com/go/datastore v1.6.0
     
       <google-codelab-step label="Google Cloud Functions に公開する" duration="0">
         <p>取得した Go のプログラムを <a href="https://womenwhogotokyo.github.io/codelab/google-cloud-shell-go?index=codelab" target="_blank">Google Cloud Shell で Go の開発をはじめよう</a> の <a href="https://womenwhogotokyo.github.io/codelab/google-cloud-shell-go/?index=codelab#3" target="_blank">Google Cloud Shell で Go のプログラムを公開する</a> の手順に従って、Google Cloud Functions に公開してみましょう。</p>
-        <p>まず、プログラムの中のProjectIDを指定します。</p>
-        <code>codelab > taskmanager > task.go</code> を開きましょう。
-        <p>プロジェクトIDに、自分のGCPプロジェクトのIDを指定します。</p>
-
-        
-        <pre>
-            <code>...
-
-            func (t Task) add() error {
-                ctx := context.Background()
-            
-                client, err := datastore.NewClient(ctx, os.Getenv("GCP_PROJECT"))
-                if err != nil {
-                    return err
-                }
-            ...
-            </code>
-        </pre>
-        <p>次に、Google Cloud Functions に公開します。</p>
+        <p>次のコマンドで、Google Cloud Functions に公開します。</p>
 <pre>$ gcloud functions deploy {Cloud Functions Name} \
 --runtime go116 \
 --entry-point TaskManager \
@@ -119,8 +101,8 @@ require cloud.google.com/go/datastore v1.6.0
 timeout: 60s
 updateTime: &#39;2019-05-11T08:11:43Z&#39;
 versionId: &#39;1&#39;</pre>
-<p>このコードラボでは、Cloud Functions Nameを環境変数にセットしてプログラム内で利用します。</p>
-<p>最後に、環境変数を設定するコマンドを実行しましょう。</p>
+<p>また、このコードラボでは、Cloud Functions NameとプロジェクトIDを環境変数にセットしてプログラム内で利用します。</p>
+<p>環境変数を設定するコマンドを実行しましょう。</p>
 <pre>$ gcloud functions deploy {Cloud Functions Name} \
 --set-env-vars GCP_PROJECT={プロジェクトID},MY_CODE={Cloud Functions Name}</pre>
 


### PR DESCRIPTION
プロジェクトIDはos.Getenvで取得するようにしたのに、記述が古かったです。